### PR TITLE
Fixed Issue With Displaying Wrong Version

### DIFF
--- a/build.txt
+++ b/build.txt
@@ -1,7 +1,7 @@
 displayName = Plethorum
 author = Beep Boop Studio
 homepage = https://discord.gg/azkt9twEkU
-version = 0.1.5
+version = 0.1.6
 hideCode = false
 hideResources = false
 buildIgnore = *.csproj, *.user, obj\*, bin\*, .vs\*

--- a/description.txt
+++ b/description.txt
@@ -1,9 +1,9 @@
-Plethorum v0.1.5
+Plethorum v0.1.6
 
 Plethorum is a large content mod, made with the intention of making yor making your modded experience better, 
 while still keeping other content mods working as they should.
 
-As of version v0.1.5, this mod adds:
+As of version v0.1.6, this mod adds:
 
 - A hardmode ore/bar/toolset
 - An endgame deathray


### PR DESCRIPTION
Some files, such as the build.txt and description.txt, etc. were showing the version v0.1.5, whereas it should be displaying v0.1.6
This also caused an Issue in the mod browser.